### PR TITLE
Cell formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uitable [![GoDoc](https://godoc.org/github.com/gosuri/uitable?status.svg)](https://godoc.org/github.com/gosuri/uitable) [![Build Status](https://travis-ci.org/gosuri/uitable.svg?branch=master)](https://travis-ci.org/gosuri/uitable)
 
-uitable is a go library for representing data as tables for terminal applications. It provides primitives for sizing and wrapping columns to improve readability.
+`uitable` is a go library for representing data as tables for terminal applications. It provides primitives for sizing and wrapping columns to improve readability. It also makes it possible to attach a formatter to each table cell, typically used to colorize terminal output.
 
 ## Example Usage
 
@@ -8,6 +8,11 @@ Full source code for the example is available at [example/main.go](example/main.
 
 ```go
 table := uitable.New()
+table.CellFormatter = func(x, y int) uitable.Formatter {
+  if y == 0 { return headerFormat }
+  if x == 0 { return nameFormat }
+  return uitable.DefaultFormatter
+}
 table.MaxColWidth = 50
 
 table.AddRow("NAME", "BIRTHDAY", "BIO")
@@ -17,18 +22,37 @@ for _, hacker := range hackers {
 fmt.Println(table)
 ```
 
-Will render the data as:
+Will render the data like:
 
-```sh
-NAME          BIRTHDAY          BIO
-Ada Lovelace  December 10, 1815 Ada was a British mathematician and writer, chi...
-Alan Turing   June 23, 1912     Alan was a British pioneering computer scientis...
-```
+<table>
+  <tr>
+    <td><b>NAME</b></td>
+    <td><b>BIRTHDAY</b></td>
+    <td><b>BIO</b></td>
+  </tr>
+  <tr>
+    <td style="color: green">Ada Lovelace</td>
+    <td>December 10, 1815</td>
+    <td>Ada was a British mathematician and writer, chi...</td>
+  </tr>
+  <tr>
+    <td  style="color: green">Alan Turing</td>
+    <td>June 23, 1912</td>
+    <td>Alan was a British pioneering computer scientis...</td>
+  </tr>
+</tr>
+
+</table>
 
 For wrapping in two columns:
 
 ```go
 table = uitable.New()
+table.CellFormatter = func(x, y int) uitable.Formatter {
+  if x == 0 { return headerFormat }
+  if x == 1 && y%4 == 0 { return nameFormat }
+  return uitable.DefaultFormatter
+}
 table.MaxColWidth = 80
 table.Wrap = true // wrap columns
 
@@ -41,20 +65,34 @@ for _, hacker := range hackers {
 fmt.Println(table)
 ```
 
-Will render the data as:
+Will render the data like:
 
-```
-Name:     Ada Lovelace
-Birthday: December 10, 1815
-Bio:      Ada was a British mathematician and writer, chiefly known for her work on
-          Charles Babbage's early mechanical general-purpose computer, the Analytical
-          Engine
-
-Name:     Alan Turing
-Birthday: June 23, 1912
-Bio:      Alan was a British pioneering computer scientist, mathematician, logician,
-          cryptanalyst and theoretical biologist
-```
+<table align="top">
+  <tr>
+    <td><b>Name:</b><td>
+    <td style="color: green">Ada Lovelace</td>
+  </tr>
+  <tr>
+    <td><b>Birthday:</b><td>
+    <td>December 10, 1815</td>
+  </tr>
+  <tr>
+    <td><b>Bio:</b><td>
+    <td>Ada was a British mathematician and writer, chiefly known for her work on Charles Babbage's early mechanical general-purpose computer, the Analytical Engine</td>
+  </tr>
+  <tr>
+    <td><b>Name:</b><td>
+    <td style="color: green">Alan Turing</td>
+  </tr>
+  <tr>
+    <td><b>Birthday:</b><td>
+    <td>June 23, 1912</td>
+  </tr>
+  <tr>
+    <td><b>Bio:</b><td>
+    <td>Alan was a British pioneering computer scientist, mathematician, logician, cryptanalyst and theoretical biologist</td>
+  </tr>
+</table>
 
 ## Installation
 

--- a/example/main.go
+++ b/example/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
+	"github.com/svenax/uitable"
 )
 
 type hacker struct {

--- a/example/main.go
+++ b/example/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/gosuri/uitable"
+	"github.com/fatih/color"
 )
 
 type hacker struct {
@@ -15,8 +15,22 @@ var hackers = []hacker{
 	{"Alan Turing", "June 23, 1912", "Alan was a British pioneering computer scientist, mathematician, logician, cryptanalyst and theoretical biologist"},
 }
 
+var (
+	headerFormat = color.New(color.FgBlack, color.Bold).SprintFunc()
+	nameFormat   = color.New(color.FgGreen).SprintFunc()
+)
+
 func main() {
 	table := uitable.New()
+	table.CellFormatter = func(x, y int) uitable.Formatter {
+		if y == 0 {
+			return headerFormat
+		}
+		if x == 0 {
+			return nameFormat
+		}
+		return uitable.DefaultFormatter
+	}
 	table.MaxColWidth = 50
 
 	fmt.Println("==> List")
@@ -28,6 +42,15 @@ func main() {
 
 	fmt.Print("\n==> Details\n")
 	table = uitable.New()
+	table.CellFormatter = func(x, y int) uitable.Formatter {
+		if x == 0 {
+			return headerFormat
+		}
+		if x == 1 && y%4 == 0 {
+			return nameFormat
+		}
+		return uitable.DefaultFormatter
+	}
 	table.MaxColWidth = 80
 	table.Wrap = true
 	for _, hacker := range hackers {

--- a/table.go
+++ b/table.go
@@ -76,6 +76,7 @@ func (t *Table) Bytes() []byte {
 	return []byte(t.String())
 }
 
+// RightAlign sets the column at index col to be right aligned
 func (t *Table) RightAlign(col int) {
 	t.mtx.Lock()
 	t.rightAlign[col] = true

--- a/table_test.go
+++ b/table_test.go
@@ -29,6 +29,18 @@ func TestCell(t *testing.T) {
 	}
 }
 
+func TestFormatCell(t *testing.T) {
+	c := &Cell{
+		Data:      "foo bar",
+		Formatter: formatter,
+	}
+
+	got := c.Formatter(c.String())
+	if got != ">>foo bar<<" {
+		t.Fatal("need", ">>foo bar<<", "got", got)
+	}
+}
+
 func TestRow(t *testing.T) {
 	row := &Row{
 		Separator: "\t",
@@ -39,6 +51,22 @@ func TestRow(t *testing.T) {
 	}
 	got := row.String()
 	need := "foo\tbar\n   \tbaz"
+
+	if got != need {
+		t.Fatalf("need: %q | got: %q ", need, got)
+	}
+}
+
+func TestFormatRow(t *testing.T) {
+	row := &Row{
+		Separator: "\t",
+		Cells: []*Cell{
+			{Data: "foo", Width: 3, Wrap: true, Formatter: formatter},
+			{Data: "bar baz", Width: 3, Wrap: true, Formatter: formatter},
+		},
+	}
+	got := row.String()
+	need := ">>foo<<\t>>bar<<\n>>   <<\t>>baz<<"
 
 	if got != need {
 		t.Fatalf("need: %q | got: %q ", need, got)
@@ -78,4 +106,8 @@ func TestAddRow(t *testing.T) {
 	if len(table.Rows) != 100 {
 		t.Fatal("want", 100, "got", len(table.Rows))
 	}
+}
+
+func formatter(s ...interface{}) string {
+	return ">>" + DefaultFormatter(s[0]) + "<<"
 }


### PR DESCRIPTION
Make it possible to attach a formatter function to each table cell. This is primarily useful to colorize terminal output, but could perhaps be used in other ways too.

The formatter function is selected by the function in`Table.CellFormatter`. Given a cells x and y coordinates, it should return a formatter function.